### PR TITLE
Ssh notification doesn't work for non root

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It shall NOT be edited by hand.
 
 A collection of Yunohost hooks to send notifications to a Gotify server
 
-[![Version: 0.1~ynh2](https://img.shields.io/badge/Version-0.1~ynh2-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/yuno_goti_notify/)
+[![Version: 0.1~ynh3](https://img.shields.io/badge/Version-0.1~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/yuno_goti_notify/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/yuno_goti_notify"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Yuno_Goti_Notify"
 description.en = "A collection of Yunohost hooks to send notifications to a Gotify server"
 description.fr = "Une collection de hooks Yunohost pour envoyer des notifications vers un serveur Gotify"
 
-version = "0.1~ynh2"
+version = "0.1~ynh3"
 
 maintainers = ["DeMiro5001"]
 

--- a/scripts/install
+++ b/scripts/install
@@ -63,7 +63,7 @@ ynh_script_progression "Adding $app's configuration files..."
 
 ynh_config_add --template="../conf/gotify_ssh_login.sh" --destination="/etc/profile.d/gotify_ssh_login_$app.sh"
 
-chmod 600 "/etc/profile.d/gotify_ssh_login_$app.sh"
+chmod 666 "/etc/profile.d/gotify_ssh_login_$app.sh"
 
 #=================================================
 # END OF SCRIPT


### PR DESCRIPTION
Script needs to be accessible by users

## Problem

- *Ssh notification doesn't work for non root*

## Solution

- *Change permission to allow it to be executed for any user*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
